### PR TITLE
Add inline implementation for Oauth2 token

### DIFF
--- a/Python-RateCard-Sample/ratecardsample.py
+++ b/Python-RateCard-Sample/ratecardsample.py
@@ -1,14 +1,37 @@
 # Using this package which is a HTTP library
 import requests
  
-# Parameters need for API
-subscription = '<subscriptionId>'
-token = '<bearerToken>'
-offer = '<offerId>'
+# Parameters needed for ratecard API
+subscription = 'your subscription ID'                 # replace with your Azure subscription ID
+#token = '<bearerToken>'                              # need to determine token at runtime, implementation below
+offer = 'MS-AZR-0003p'                                # PAYG offer
 currency = 'USD'
 locale = 'en-US'
 region = 'US'
 rateCardUrl = "https://management.azure.com:443/subscriptions/{subscriptionId}/providers/Microsoft.Commerce/RateCard?api-version=2016-08-31-preview&$filter=OfferDurableId eq '{offerId}' and Currency eq '{currencyId}' and Locale eq '{localeId}' and RegionInfo eq '{regionId}'".format(subscriptionId = subscription, offerId = offer, currencyId = currency, localeId = locale, regionId = region)
+
+# Parameters needed for Oauth2 API
+grant_type = 'client_credentials'                     # static
+client_id = 'your client ID'                          # replace with your client ID (App registration in AAD) 
+client_secret = 'your client secret'                  # replace with your client secret (from the same App registration)
+resource = 'https://management.azure.com/'            # static
+oauthUrl1 = 'https://login.microsoftonline.com/'      # static
+tenant_id = 'yourAADtenant.onmicrosoft.com'           # replace with your AD tenant ID
+oauthUr2 = '/oauth2/token'                            # static
+
+# Prepare paramters to be sent to api for Oauth2 token
+URL = oauthUrl1 + tenant_id + '/oauth2/token'
+
+PARAMS = {  'grant_type':    grant_type, 
+            'client_id':     client_id,
+            'client_secret': client_secret, 
+            'resource':      resource}
+
+# Request an OAuth2 bearer token, sending post request and saving response as response object 
+r1 = requests.post(url = URL, data = PARAMS)
+
+# Extract the Oauth2 token from the response
+token = r1.json()['access_token']
 
 # Don't allow redirects and call the RateCard API
 response = requests.get(rateCardUrl, allow_redirects=False, headers = {'Authorization': 'Bearer %s' %token})


### PR DESCRIPTION


## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The sample code by itself wasn't that useful as it required you to know how to create a token and then pass that to this program, meaning the current code can't be used standalone. Added an inline implementation for the Oauth2 token that is then used to call the ratecard API

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```Add your Subscription ID, Tenant ID, Client ID, Client Secret to the code.
```Run the program and you should retrieve the ratecard results successfully.

## What to Check
Verify that the following are valid
* Verify that your Subscription ID, Tenant ID, Client ID, Client Secret are known and populated.

## Other Information
<!-- Add any other helpful information that may be needed here. -->